### PR TITLE
Fixed issues with camera

### DIFF
--- a/core/src/com/davidfabio/game/Camera.java
+++ b/core/src/com/davidfabio/game/Camera.java
@@ -23,13 +23,15 @@ public class Camera extends OrthographicCamera {
     }
 
     private void moveTowards(float otherX, float otherY, float deltaTime) {
-        float dir = getAngleTowards(otherX, otherY);
+        float dir = this.getAngleTowards(otherX, otherY);
         // Increase camera speed when distance to player is large, so that the player never goes
         // out of view.
-        float distanceToPlayer = getDistanceTo(otherX, otherY);
-        float speedMultiplier = distanceToPlayer > 240 ? (distanceToPlayer / 240 * 2) : 1.0f;
-        float speed = Camera.MOVEMENT_SPEED * deltaTime * speedMultiplier;
-        moveTowardsWSpeed(dir, deltaTime, speed);
+        float distanceToPlayer = this.getDistanceTo(otherX, otherY);
+        if (distanceToPlayer * deltaTime > 0.5f) {
+            float speedMultiplier = distanceToPlayer > 240 ? (distanceToPlayer / 240 * 2) : 1.0f;
+            float speed = Camera.MOVEMENT_SPEED * deltaTime * speedMultiplier;
+            this.moveTowardsWSpeed(dir, speed);
+        }
     }
 
     private float getAngleTowards(float otherX, float otherY) {
@@ -42,7 +44,7 @@ public class Camera extends OrthographicCamera {
         return (float)Math.sqrt((distanceX * distanceX) + (distanceY * distanceY));
     }
 
-    public void moveTowardsWSpeed(float direction, float deltaTime, float speed) {
+    public void moveTowardsWSpeed(float direction, float speed) {
         float deltaX = (float)Math.cos(direction) * speed;
         float deltaY = (float)Math.sin(direction) * speed;
 

--- a/core/src/com/davidfabio/game/Game.java
+++ b/core/src/com/davidfabio/game/Game.java
@@ -19,20 +19,23 @@ public class Game extends ApplicationAdapter {
 
 	private Random random;
 	private ShapeRenderer shape;
-	private Camera camera;
-	private Stage stage;
+	private static Camera camera;
+	private static Stage stage;
 
 	// for testing only
 	private static float timeElapsed = 0;
 	public static float getTimeElapsed() { return timeElapsed; }
+	public static Camera getCamera() {
+		return camera;
+	}
 
 
 	@Override public void create () {
 		random = new Random();
 
 		shape = new ShapeRenderer();
-		this.camera = new Camera();
-		this.stage = new Stage();
+		camera = new Camera();
+		stage = new Stage();
 		Sounds.loadSounds();
 
 		player = new Player();

--- a/core/src/com/davidfabio/game/Inputs.java
+++ b/core/src/com/davidfabio/game/Inputs.java
@@ -2,6 +2,7 @@ package com.davidfabio.game;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.Input.Buttons;
+import com.badlogic.gdx.math.Vector3;
 
 import java.util.ArrayList;
 
@@ -45,8 +46,15 @@ public class Inputs {
         public static int getY() { return y; }
 
         static void update() {
-            x = Gdx.input.getX();
-            y = Gdx.input.getY();
+            Camera gameCamera = Game.getCamera();
+            if (gameCamera != null) {
+                Vector3 unprojectedCoords = gameCamera.unproject(new Vector3(Gdx.input.getX(), Gdx.input.getY(), 0));
+                x = (int)unprojectedCoords.x;
+                y = (int)unprojectedCoords.y;
+            } else {
+                x = Gdx.input.getX();
+                y = Gdx.input.getY();
+            }
             left.update();
             right.update();
             middle.update();


### PR DESCRIPTION
Fixed issues with camera:
- #27 : Jittering comes from the floating point precision when the Camera is pretty much centered on the player. Since they rarely perfectly align, the camera tries to "fix" its position and in doing so it moves in the opposite direction. This is fixed by stopping the camera movement when it's close enough to the player.
- #25 : Aiming was off because the Mouse-Coordinates need to be un-projected in respect to the camera. LibGDX provides a handy function which handles this exact issue.