### PR TITLE
Repositioned Player and Camera in the middle of the level, not the window

### DIFF
--- a/src/main/java/org/davidfabio/game/Camera.java
+++ b/src/main/java/org/davidfabio/game/Camera.java
@@ -10,7 +10,7 @@ public class Camera extends OrthographicCamera {
     public Camera(Level level) {
         super();
         this.setToOrtho(true, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-        this.position.set(this.viewportWidth / 2f, this.viewportHeight / 2f, 0);
+        this.position.set(level.getWidth() / 2f, level.getHeight() / 2f, 0);
         this.finalZoom = calcOptimalZoom(level);    // calculates the optimal zoom to show a little less than the whole level
         this.zoom = 0.5f * this.finalZoom;   // We start zoomed in
     }

--- a/src/main/java/org/davidfabio/game/World.java
+++ b/src/main/java/org/davidfabio/game/World.java
@@ -37,7 +37,7 @@ public class World {
         this.scores = scores;
 
         this.player = new Player();
-        this.player.init(Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2, 32, 240, Color.GOLD);
+        this.player.init(this.level.getWidth() / 2, this.level.getHeight() / 2, 32, 240, Color.GOLD);
 
         this.enemies = new ArrayList<>();
         this.enemiesTemp = new ArrayList<>();


### PR DESCRIPTION
This PR fixes #88 .
The player was still positioned relatively to the window. By repositioning the player in the middle of the level, another issue arised: The camera was also positioned in the wrong place.

Now both Player and Camera are positioned correctly.
Various level and window sizes were tested and now everything is centered as it should be.