### PR TITLE
Fixed wrong assignment of scores in World creation

### DIFF
--- a/src/main/java/org/davidfabio/game/World.java
+++ b/src/main/java/org/davidfabio/game/World.java
@@ -41,7 +41,7 @@ public class World {
     public World(ArrayList<Score> scores) {
         level = new Level(Settings.levelWidth, Settings.levelHeight);
         score = new Score();
-        scores = scores;
+        this.scores = scores;
 
         player = new Player();
         player.init(level.getWidth() / 2, level.getHeight() / 2, 32, 240, Color.GOLD);


### PR DESCRIPTION
The scores list was not assigned correctly in the World class. The assignment is now correct again.
This fixes #111 