### PR TITLE
Fixed rendering on MacOS

### DIFF
--- a/src/main/java/org/davidfabio/game/Collision.java
+++ b/src/main/java/org/davidfabio/game/Collision.java
@@ -104,8 +104,4 @@ public class Collision {
 
         return true;
     }
-
-
-
-
 }

--- a/src/main/java/org/davidfabio/game/Enemy.java
+++ b/src/main/java/org/davidfabio/game/Enemy.java
@@ -76,9 +76,11 @@ public class Enemy extends Entity implements Attackable, Attacker {
         if (!getIsActive())
             return;
 
-        if (getIsSpawning())
+        if (getIsSpawning()) {
+            polygonSpriteBatch.begin();
             getShape().renderOutline(shapeRenderer, getColor());
-        else
+            polygonSpriteBatch.end();
+        } else
             super.render(polygonSpriteBatch, shapeRenderer);
     }
 

--- a/src/main/java/org/davidfabio/game/Entity.java
+++ b/src/main/java/org/davidfabio/game/Entity.java
@@ -62,6 +62,8 @@ public class Entity implements Movable {
         if (!isActive)
             return;
 
+        polygonSpriteBatch.begin();
         shape.render(polygonSpriteBatch, color);
+        polygonSpriteBatch.end();
     }
 }

--- a/src/main/java/org/davidfabio/game/Pickup.java
+++ b/src/main/java/org/davidfabio/game/Pickup.java
@@ -31,9 +31,11 @@ public class Pickup extends Entity implements Movable {
             return;
 
         if (lifespanCounter > startBlinkingAfter) {
+            polygonSpriteBatch.begin();
             Color _color = getColorInitial();
             _color.a = transparencyWhileBlinking;
             getShape().render(polygonSpriteBatch, _color);
+            polygonSpriteBatch.end();
         }
         else
             super.render(polygonSpriteBatch, shapeRenderer);

--- a/src/main/java/org/davidfabio/game/Player.java
+++ b/src/main/java/org/davidfabio/game/Player.java
@@ -85,6 +85,7 @@ public class Player extends Entity implements Attackable {
 
 
     public void render(PolygonSpriteBatch polygonSpriteBatch, ShapeRenderer shapeRenderer) {
+        polygonSpriteBatch.begin();
         // main shape (circle)
         Color color = getColor();
         if (isInHitState)
@@ -102,9 +103,7 @@ public class Player extends Entity implements Attackable {
             float endX = Transform2D.translateX(getX(), getAngle(), dashLineLength);
             float endY = Transform2D.translateY(getY(), getAngle(), dashLineLength);
             shapeRenderer.line(getX(), getY(), endX, endY);
-
             shapeRenderer.circle(endX, endY, getScale() / 2);
-
             shapeRenderer.end();
         }
 
@@ -117,6 +116,7 @@ public class Player extends Entity implements Attackable {
                 getShape().render(polygonSpriteBatch, _color);
             }
         }
+        polygonSpriteBatch.end();
 
         // bullets
         for (int i = 0; i < Settings.MAX_PLAYER_BULLETS; i += 1)

--- a/src/main/java/org/davidfabio/game/World.java
+++ b/src/main/java/org/davidfabio/game/World.java
@@ -123,8 +123,6 @@ public class World {
         // render player / player bullets
         player.render(polygonSpriteBatch, shapeRenderer);
 
-        polygonSpriteBatch.end();
-
         // render level
         level.render(shapeRenderer);
     }

--- a/src/main/java/org/davidfabio/ui/GameScreen.java
+++ b/src/main/java/org/davidfabio/ui/GameScreen.java
@@ -99,7 +99,6 @@ public class GameScreen extends ScreenAdapter {
         this.camera.updateCameraPosition(deltaTime, this.world.getPlayer());
         this.shapeRenderer.setProjectionMatrix(this.camera.combined);
 
-        this.polygonSpriteBatch.begin();
         this.polygonSpriteBatch.setProjectionMatrix(this.camera.combined);
         this.world.render(this.polygonSpriteBatch,this.shapeRenderer);
         this.stage.draw();


### PR DESCRIPTION
This PR fixes the rendering issues we've encountered on macOS.
The problem seems to be a large rendering batch which macOS must handle differently to windows.
In order to fix this, every Entities-Rendering-method simply receives an own rendering batch.

By doing this the colors are now again correctly rendered and everything else looks as it needs to be.
This was tested on a Macbook Pro 16 (Intel) and a DELL Inspiron Windows Laptop.

This PR fixes #114 .