### PR TITLE
Reenabled Background music and added Sound effects to settings

### DIFF
--- a/src/main/java/org/davidfabio/Duality.java
+++ b/src/main/java/org/davidfabio/Duality.java
@@ -2,6 +2,7 @@ package org.davidfabio;
 
 import com.badlogic.gdx.Game;
 import org.davidfabio.game.Score;
+import org.davidfabio.game.Sounds;
 import org.davidfabio.ui.GameScreen;
 import org.davidfabio.ui.MainMenuScreen;
 
@@ -13,7 +14,9 @@ public class Duality extends Game {
 	@Override
 	public void create() {
 		scores = new ArrayList<>();
-		//setScreen(new MainMenuScreen(scores));
-		setScreen(new GameScreen(scores));
+		Sounds.loadSounds();	// Initialize Sounds from current Settings.
+		//
+		setScreen(new MainMenuScreen(scores));
+		//setScreen(new GameScreen(scores));
 	}
 }

--- a/src/main/java/org/davidfabio/game/Sounds.java
+++ b/src/main/java/org/davidfabio/game/Sounds.java
@@ -6,44 +6,55 @@ import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
 public class Sounds {
-    private static Sound sfxShoot, sfxExplosion, sfxHit;
-    private static Sound musicTrack;
+    private static Sound sfxShoot = null, sfxExplosion = null, sfxHit = null;
+    private static Sound musicTrack = null;
 
     public static void loadSounds() {
-        try {
-            sfxShoot = Gdx.audio.newSound(Gdx.files.internal("src/main/resources/sfx/shoot1.wav"));
-        }
-        catch (GdxRuntimeException ex) {
-            sfxShoot = null;
-            System.out.println("Sound could not be loaded.\n" + ex.getMessage());
+        if (Settings.sfxEnabled) {
+            if(sfxShoot == null) {
+                try {
+                    sfxShoot = Gdx.audio.newSound(Gdx.files.internal("src/main/resources/sfx/shoot1.wav"));
+                }
+                catch (GdxRuntimeException ex) {
+                    sfxShoot = null;
+                    System.out.println("Sound could not be loaded.\n" + ex.getMessage());
+                }
+            }
+
+            if(sfxExplosion == null) {
+                try {
+                    sfxExplosion = Gdx.audio.newSound(Gdx.files.internal("src/main/resources/sfx/explosion1.wav"));
+                }
+                catch (GdxRuntimeException ex) {
+                    sfxExplosion = null;
+                    System.out.println("Sound could not be loaded.\n" + ex.getMessage());
+                }
+            }
+
+            if(sfxHit == null) {
+                try {
+                    sfxHit = Gdx.audio.newSound(Gdx.files.internal("src/main/resources/sfx/shoot5.wav"));
+                }
+                catch (GdxRuntimeException ex) {
+                    sfxHit = null;
+                    System.out.println("Sound could not be loaded.\n" + ex.getMessage());
+                }
+            }
         }
 
-        try {
-            sfxExplosion = Gdx.audio.newSound(Gdx.files.internal("src/main/resources/sfx/explosion1.wav"));
+        if (Settings.musicEnabled) {
+            if (musicTrack == null ) {
+                try {
+                    // Note: Loading Music still takes very long.
+                    // However, this is done once and not more often.
+                    musicTrack = Gdx.audio.newSound(Gdx.files.internal("src/main/resources/music/track1.mp3"));
+                }
+                catch (GdxRuntimeException ex) {
+                    musicTrack = null;
+                    System.out.println("Sound could not be loaded.\n" + ex.getMessage());
+                }
+            }
         }
-        catch (GdxRuntimeException ex) {
-            sfxExplosion = null;
-            System.out.println("Sound could not be loaded.\n" + ex.getMessage());
-        }
-
-        try {
-            sfxHit = Gdx.audio.newSound(Gdx.files.internal("src/main/resources/sfx/shoot5.wav"));
-        }
-        catch (GdxRuntimeException ex) {
-            sfxHit = null;
-            System.out.println("Sound could not be loaded.\n" + ex.getMessage());
-        }
-
-        // NOTE (David): this is commented out for now, because it makes the game load very slowly
-        /*
-        try {
-            musicTrack = Gdx.audio.newSound(Gdx.files.internal("src/main/resources/music/track1.mp3"));
-        }
-        catch (GdxRuntimeException ex) {
-            musicTrack = null;
-            System.out.println("Sound could not be loaded.\n" + ex.getMessage());
-        }
-        */
     }
 
     public static void playHitSfx() {
@@ -60,13 +71,19 @@ public class Sounds {
 
     public static void playExplosionSfx() {
         if ((sfxExplosion != null) && (Settings.sfxEnabled)) {
-            sfxExplosion.play(Settings.sfxVolume);
+            sfxExplosion.loop(Settings.sfxVolume);
         }
     }
 
     public static void playBackgroundMusic() {
         if ((musicTrack != null) && (Settings.musicEnabled)) {
             musicTrack.play(Settings.musicVolume);
+        }
+    }
+
+    public static void stopBackgroundMusic() {
+        if ((musicTrack != null) && Settings.musicEnabled) {
+            musicTrack.stop();
         }
     }
 }

--- a/src/main/java/org/davidfabio/game/World.java
+++ b/src/main/java/org/davidfabio/game/World.java
@@ -90,6 +90,7 @@ public class World {
         this.player.update(deltaTime, this); // player bullets get updated here as well
         if (player.getHealth() <= 0) {
             score.end();
+            Sounds.stopBackgroundMusic();
             ((Duality)Gdx.app.getApplicationListener()).setScreen(new GameOverScreen(scores, score));
         }
 

--- a/src/main/java/org/davidfabio/ui/GameScreen.java
+++ b/src/main/java/org/davidfabio/ui/GameScreen.java
@@ -53,6 +53,7 @@ public class GameScreen extends ScreenAdapter {
         this.camera = new Camera(this.world.getLevel());
         this.stage = new Stage();
         Sounds.loadSounds();
+        Sounds.playBackgroundMusic();
 
         this.userInterface = new UserInterface();
         this.userInterface.init(this.world.getPlayer(),this.world.getScore());
@@ -70,16 +71,22 @@ public class GameScreen extends ScreenAdapter {
 
         Inputs.update();
 
-        if (Inputs.esc.getWasPressed())
+        if (Inputs.esc.getWasPressed()) {
             isPaused = !isPaused;
+            if (isPaused)
+                Sounds.stopBackgroundMusic();
+            else
+                Sounds.playBackgroundMusic();
+        }
 
         // restart game
         // TODO (David): quick and dirty solution; e.g. all the sounds get reloaded again, which is unnecessary
         if (Inputs.tab.getWasPressed())
             show();
 
-        if (isPaused)
+        if (isPaused) {
             return;
+        }
 
 
 

--- a/src/main/java/org/davidfabio/ui/SettingsScreen.java
+++ b/src/main/java/org/davidfabio/ui/SettingsScreen.java
@@ -2,6 +2,7 @@ package org.davidfabio.ui;
 
 import org.davidfabio.Duality;
 import org.davidfabio.game.Score;
+import org.davidfabio.game.Sounds;
 import org.davidfabio.utils.Settings;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.ScreenAdapter;
@@ -44,6 +45,7 @@ public class SettingsScreen extends ScreenAdapter {
             @Override
             public void clicked(InputEvent event, float x, float y) {
                 Settings.sfxEnabled = !Settings.sfxEnabled;
+                Sounds.loadSounds();
             }
         });
         UIBuilder.addCheckBox(this.mainTable,"Fullscreen", Settings.fullscreenEnabled,false, new ClickListener() {
@@ -59,6 +61,7 @@ public class SettingsScreen extends ScreenAdapter {
             public void changed(ChangeEvent event, Actor actor) {
                 Slider slider = (Slider)event.getListenerActor();
                 Settings.sfxVolume = slider.getValue();
+                Sounds.playHitSfx();
             }
         });
         UIBuilder.addSubtitleLabel(this.mainTable,"Music",true);
@@ -67,6 +70,7 @@ public class SettingsScreen extends ScreenAdapter {
             @Override
             public void clicked(InputEvent event, float x, float y) {
                 Settings.musicEnabled = !Settings.musicEnabled;
+                Sounds.loadSounds();
             }
         });
         UIBuilder.addTextInput(this.mainTable, Settings.username, false, new ChangeListener() {


### PR DESCRIPTION
This PR re-enables the Background Music during the Gameplay.
The Background Music file is only loaded when enabled to avoid unnecessary long loading times for the game.

The Sound Settings now also play a short SFX to understand how loud the SFX will be once the game starts.

This PR closes #38 and fixes #91 .